### PR TITLE
Add a call to ReplaceAll to sub _ for hyphens

### DIFF
--- a/snowflake.go
+++ b/snowflake.go
@@ -160,6 +160,7 @@ func (s *SnowflakeSQL) generateUsername(req dbplugin.NewUserRequest) (string, er
 		credsutil.RoleName(req.UsernameConfig.RoleName, maxRolenameChunkLen),
 		credsutil.MaxLength(maxIdentifierLength),
 	)
+	username = strings.ReplaceAll(username, "-", "_")
 	if err != nil {
 		return "", errwrap.Wrapf("error generating username: {{err}}", err)
 	}


### PR DESCRIPTION
Snowflake doesn't allow hyphens in usernames. As such, this change will remove all hyphens from the username and replace them with underscores.