### PR TITLE
Update test to conditionally add region segment to the DSN

### DIFF
--- a/snowflake_test.go
+++ b/snowflake_test.go
@@ -321,7 +321,10 @@ func testCredentialsExist(connString, username, password string) error {
 	if err != nil {
 		return err
 	}
-	connURL := fmt.Sprintf("%s:%s@%s.%s", username, password, conf.Account, conf.Region)
+	connURL := fmt.Sprintf("%s:%s@%s", username, password, conf.Account)
+	if conf.Region != "" {
+		connURL = fmt.Sprintf("%s.%s", connURL, conf.Region)
+	}
 
 	db, err := sql.Open("snowflake", connURL)
 	if err != nil {


### PR DESCRIPTION
## Description

This PR updates test code to conditionally add the region segment to the DSN when testing if credentials exist. This allowed me to successfully run the tests using an instance in [AWS US West (Oregon)](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#locator-formats-by-cloud-platform-and-region), where the region segment is empty.

## Testing

```
$ VAULT_ACC=1 SNOWFLAKE_ACCOUNT='LWA62894' SNOWFLAKE_USER='VAULT_DB_USER' SNOWFLAKE_PASSWORD='******' go test -v
=== RUN   TestSnowflakeSQL_Initialize
--- PASS: TestSnowflakeSQL_Initialize (0.79s)
=== RUN   TestSnowflake_NewUser
=== RUN   TestSnowflake_NewUser/name_creation
=== RUN   TestSnowflake_NewUser/username_creation
=== RUN   TestSnowflake_NewUser/empty_creation
2021/03/23 12:12:15 query issue: 001003 (42000): SQL compilation error:
syntax error line 1 at position 10 unexpected '<EOF>'.
--- PASS: TestSnowflake_NewUser (5.44s)
    --- PASS: TestSnowflake_NewUser/name_creation (2.30s)
    --- PASS: TestSnowflake_NewUser/username_creation (2.83s)
    --- PASS: TestSnowflake_NewUser/empty_creation (0.31s)
=== RUN   TestSnowflake_RenewUser
--- PASS: TestSnowflake_RenewUser (6.29s)
=== RUN   TestSnowflake_RevokeUser
=== RUN   TestSnowflake_RevokeUser/default_revoke
=== RUN   TestSnowflake_RevokeUser/name_revoke
=== RUN   TestSnowflake_RevokeUser/username_revoke
--- PASS: TestSnowflake_RevokeUser (9.77s)
    --- PASS: TestSnowflake_RevokeUser/default_revoke (3.09s)
    --- PASS: TestSnowflake_RevokeUser/name_revoke (2.94s)
    --- PASS: TestSnowflake_RevokeUser/username_revoke (3.74s)
PASS
ok      github.com/hashicorp/vault-plugin-database-snowflake    22.578s
```
