### PR TITLE
SnowflakeDB - Add username customization

### DIFF
--- a/snowflake.go
+++ b/snowflake.go
@@ -9,21 +9,17 @@ import (
 	"time"
 
 	"github.com/hashicorp/errwrap"
-
 	"github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/hashicorp/vault/sdk/database/helper/connutil"
-	"github.com/hashicorp/vault/sdk/database/helper/credsutil"
 	"github.com/hashicorp/vault/sdk/database/helper/dbutil"
 	"github.com/hashicorp/vault/sdk/helper/dbtxn"
 	"github.com/hashicorp/vault/sdk/helper/strutil"
+	"github.com/hashicorp/vault/sdk/helper/template"
 	_ "github.com/snowflakedb/gosnowflake"
 )
 
 const (
 	snowflakeSQLTypeName     = "snowflake"
-	maxIdentifierLength      = 255
-	maxUsernameChunkLen      = 32 // arbitrarily chosen
-	maxRolenameChunkLen      = 32 // arbitrarily chosen
 	defaultSnowflakeRenewSQL = `
 alter user {{name}} set DAYS_TO_EXPIRY = {{expiration}};
 `
@@ -33,6 +29,7 @@ alter user {{name}} set PASSWORD = '{{password}}';
 	defaultSnowflakeDeleteSQL = `
 drop user {{name}};
 `
+	defaultUserNameTemplate = `{{ printf "v_%s_%s_%s_%s" (.DisplayName | truncate 32) (.RoleName | truncate 32) (random 20) (unix_time) | truncate 255 | replace "-" "_" }}`
 )
 
 var (
@@ -65,6 +62,8 @@ func new() *SnowflakeSQL {
 
 type SnowflakeSQL struct {
 	*connutil.SQLConnectionProducer
+
+	usernameProducer template.StringTemplate
 }
 
 func (s *SnowflakeSQL) Type() (string, error) {
@@ -86,10 +85,28 @@ func (s *SnowflakeSQL) Initialize(ctx context.Context, req dbplugin.InitializeRe
 		return dbplugin.InitializeResponse{}, err
 	}
 
+	usernameTemplate, err := strutil.GetString(req.Config, "username_template")
+	if err != nil {
+		return dbplugin.InitializeResponse{}, fmt.Errorf("failed to retrieve username_template: %w", err)
+	}
+	if usernameTemplate == "" {
+		usernameTemplate = defaultUserNameTemplate
+	}
+
+	up, err := template.NewTemplate(template.Template(usernameTemplate))
+	if err != nil {
+		return dbplugin.InitializeResponse{}, fmt.Errorf("unable to initialize username template: %w", err)
+	}
+	s.usernameProducer = up
+
+	_, err = s.usernameProducer.Generate(dbplugin.UsernameMetadata{})
+	if err != nil {
+		return dbplugin.InitializeResponse{}, fmt.Errorf("invalid username template: %w", err)
+	}
+
 	resp := dbplugin.InitializeResponse{
 		Config: req.Config,
 	}
-
 	return resp, nil
 }
 
@@ -155,12 +172,8 @@ func (s *SnowflakeSQL) NewUser(ctx context.Context, req dbplugin.NewUserRequest)
 }
 
 func (s *SnowflakeSQL) generateUsername(req dbplugin.NewUserRequest) (string, error) {
-	username, err := credsutil.GenerateUsername(
-		credsutil.DisplayName(req.UsernameConfig.DisplayName, maxUsernameChunkLen),
-		credsutil.RoleName(req.UsernameConfig.RoleName, maxRolenameChunkLen),
-		credsutil.MaxLength(maxIdentifierLength),
-	)
-	username = strings.ReplaceAll(username, "-", "_")
+	username, err := s.usernameProducer.Generate(req.UsernameConfig)
+
 	if err != nil {
 		return "", errwrap.Wrapf("error generating username: {{err}}", err)
 	}

--- a/snowflake_test.go
+++ b/snowflake_test.go
@@ -15,7 +15,6 @@ import (
 	dbtesting "github.com/hashicorp/vault/sdk/database/dbplugin/v5/testing"
 	"github.com/snowflakedb/gosnowflake"
 	"github.com/stretchr/testify/require"
-
 )
 
 const (

--- a/snowflake_test.go
+++ b/snowflake_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	dbtesting "github.com/hashicorp/vault/sdk/database/dbplugin/v5/testing"
 	"github.com/snowflakedb/gosnowflake"
+	"github.com/stretchr/testify/require"
+
 )
 
 const (
@@ -278,6 +280,95 @@ func TestSnowflake_RevokeUser(t *testing.T) {
 			assertCredentialsDoNotExist(t, connURL, createResp.Username, password)
 		})
 	}
+}
+
+func TestSnowflake_DefaultUsernameTemplate(t *testing.T) {
+	if !runAcceptanceTests {
+		t.SkipNow()
+	}
+
+	connURL := connUrl(t)
+
+	db := new()
+	defer dbtesting.AssertClose(t, db)
+
+	initReq := dbplugin.InitializeRequest{
+		Config: map[string]interface{}{
+			"connection_url": connURL,
+		},
+		VerifyConnection: true,
+	}
+	dbtesting.AssertInitialize(t, db, initReq)
+
+	password := "y8fva_sdVA3rasf"
+	createReq := dbplugin.NewUserRequest{
+		UsernameConfig: dbplugin.UsernameMetadata{
+			DisplayName: "test",
+			RoleName:    "test",
+		},
+		Statements: dbplugin.Statements{
+			Commands: []string{`
+				CREATE USER {{name}} PASSWORD = '{{password}}';
+				GRANT ROLE myrole TO USER {{name}};`,
+			},
+		},
+		Password:   password,
+		Expiration: time.Now().Add(time.Hour),
+	}
+	createResp := dbtesting.AssertNewUser(t, db, createReq)
+
+	if createResp.Username == "" {
+		t.Fatalf("Missing username")
+	}
+
+	assertCredentialsExist(t, connURL, createResp.Username, password)
+
+	require.Regexp(t, `^v_test_test_[a-zA-Z0-9]{20}_[0-9]{10}$`, createResp.Username)
+}
+
+func TestSnowflake_CustomUsernameTemplate(t *testing.T) {
+	if !runAcceptanceTests {
+		t.SkipNow()
+	}
+
+	connURL := connUrl(t)
+
+	db := new()
+	defer dbtesting.AssertClose(t, db)
+
+	initReq := dbplugin.InitializeRequest{
+		Config: map[string]interface{}{
+			"connection_url": connURL,
+			"username_template": "{{.DisplayName}}_{{random 10}}",
+		},
+		VerifyConnection: true,
+	}
+	dbtesting.AssertInitialize(t, db, initReq)
+
+	password := "y8fva_sdVA3rasf"
+	createReq := dbplugin.NewUserRequest{
+		UsernameConfig: dbplugin.UsernameMetadata{
+			DisplayName: "test",
+			RoleName:    "test",
+		},
+		Statements: dbplugin.Statements{
+			Commands: []string{`
+				CREATE USER {{name}} PASSWORD = '{{password}}';
+				GRANT ROLE myrole TO USER {{name}};`,
+			},
+		},
+		Password:   password,
+		Expiration: time.Now().Add(time.Hour),
+	}
+	createResp := dbtesting.AssertNewUser(t, db, createReq)
+
+	if createResp.Username == "" {
+		t.Fatalf("Missing username")
+	}
+
+	assertCredentialsExist(t, connURL, createResp.Username, password)
+
+	require.Regexp(t, `^test_[a-zA-Z0-9]{10}$`, createResp.Username)
 }
 
 func dsnString() (string, error) {


### PR DESCRIPTION
# Overview
Adds the ability to customize username generation for dynamic users in Elasticsearch.

Uses the new field `username_template` with the [go template language](https://golang.org/pkg/text/template/).