### PR TITLE
Update Vault SDK with bug fix for external plugin execution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
-	github.com/hashicorp/vault/sdk v0.4.2-0.20220517162126-0f1784dce27a
+	github.com/hashicorp/vault/sdk v0.5.1-0.20220603231509-4ac2b575faf5
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/snowflakedb/gosnowflake v1.6.3
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/hashicorp/go-secure-stdlib/base62 v0.1.1/go.mod h1:EdWO6czbmthiwZ3/PU
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.1 h1:cCRo8gK7oq6A2L6LICkUZ+/a5rLiRXFMf1Qd4xSwxTc=
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.1/go.mod h1:zq93CJChV6L9QTfGKtfBxKqD7BqqXx5O04A/ns2p5+I=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
-github.com/hashicorp/go-secure-stdlib/parseutil v0.1.5 h1:MBgwAFPUbfuI0+tmDU/aeM1MARvdbqWmiieXIalKqDE=
-github.com/hashicorp/go-secure-stdlib/parseutil v0.1.5/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
+github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 h1:om4Al8Oy7kCm/B86rLCLah4Dt5Aa0Fr5rYBG60OzwHQ=
+github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/password v0.1.1/go.mod h1:9hH302QllNwu1o2TGYtSk8I8kTAN0ca1EHpwhm5Mmzo=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.1/go.mod h1:gKOamz3EwoIoJq7mlMIRBpVTAUn8qPCrEclOKKWhD3U=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 h1:kes8mmyCpxJsI7FTwtzRqEy9CdjCtrXrXGuOpxEA7Ts=
@@ -180,8 +180,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/vault/sdk v0.4.2-0.20220517162126-0f1784dce27a h1:0Tz/dWC3dzBcWLyYsc+83I0/JsQQnlK41fRh9n8lyyc=
-github.com/hashicorp/vault/sdk v0.4.2-0.20220517162126-0f1784dce27a/go.mod h1:UJZHlfwj7qUJG8g22CuxUgkdJouFrBNvBHCyx8XAPdo=
+github.com/hashicorp/vault/sdk v0.5.1-0.20220603231509-4ac2b575faf5 h1:79X8/x8owo4i/73JcFJNFeD5Hh1yUE0cQzKRr+2z7nA=
+github.com/hashicorp/vault/sdk v0.5.1-0.20220603231509-4ac2b575faf5/go.mod h1:SAFvvhkLHw7olfm6eQpZbMxGIVpPjNW9LLGCEWeeeCA=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/snowflake_test.go
+++ b/snowflake_test.go
@@ -57,7 +57,7 @@ func TestSnowflakeSQL_Initialize(t *testing.T) {
 
 	expectedConfig := map[string]interface{}{
 		"connection_url": connURL,
-		dbplugin.SupportedCredentialTypesKey: []string{
+		dbplugin.SupportedCredentialTypesKey: []interface{}{
 			dbplugin.CredentialTypePassword.String(),
 			dbplugin.CredentialTypeRSAPrivateKey.String(),
 		},


### PR DESCRIPTION
This PR updates the Vault SDK to bring in a bug fix from https://github.com/hashicorp/vault/pull/15801. The bug fix allows the plugin to run external to Vault after recent additions to support key pair credentials.

Steps taken:
1. `go get github.com/hashicorp/vault/sdk@main`
2. `go mod tidy`

Acceptance test output:
```
$ SNOWFLAKE_ACCOUNT=redacted.east-us-2.azure SNOWFLAKE_USER=redacted SNOWFLAKE_PASSWORD=redacted SNOWFLAKE_DATABASE=DEMO_DB VAULT_ACC=1 go test -v    
=== RUN   TestSnowflakeSQL_Initialize
--- PASS: TestSnowflakeSQL_Initialize (1.61s)
=== RUN   TestSnowflake_NewUser
=== RUN   TestSnowflake_NewUser/new_user_with_password_credential_using_username_and_split_statements
=== RUN   TestSnowflake_NewUser/new_user_with_2048_bit_rsa_private_key_credential
=== RUN   TestSnowflake_NewUser/new_user_with_3072_bit_rsa_private_key_credential
=== RUN   TestSnowflake_NewUser/new_user_with_4096_bit_rsa_private_key_credential_and_split_statements
=== RUN   TestSnowflake_NewUser/new_user_with_empty_creation_statements
=== RUN   TestSnowflake_NewUser/new_user_with_password_credential_using_name
--- PASS: TestSnowflake_NewUser (22.18s)
    --- PASS: TestSnowflake_NewUser/new_user_with_password_credential_using_username_and_split_statements (4.53s)
    --- PASS: TestSnowflake_NewUser/new_user_with_2048_bit_rsa_private_key_credential (4.70s)
    --- PASS: TestSnowflake_NewUser/new_user_with_3072_bit_rsa_private_key_credential (3.63s)
    --- PASS: TestSnowflake_NewUser/new_user_with_4096_bit_rsa_private_key_credential_and_split_statements (4.49s)
    --- PASS: TestSnowflake_NewUser/new_user_with_empty_creation_statements (0.73s)
    --- PASS: TestSnowflake_NewUser/new_user_with_password_credential_using_name (4.10s)
=== RUN   TestSnowflake_RenewUser
--- PASS: TestSnowflake_RenewUser (7.05s)
=== RUN   TestSnowflake_RevokeUser
=== RUN   TestSnowflake_RevokeUser/username_revoke
ERRO[0034]log.go:240 gosnowflake.(*defaultLogger).Errorln Authentication FAILED                        
=== RUN   TestSnowflake_RevokeUser/default_revoke
ERRO[0039]log.go:240 gosnowflake.(*defaultLogger).Errorln Authentication FAILED                        
=== RUN   TestSnowflake_RevokeUser/name_revoke
ERRO[0042]log.go:240 gosnowflake.(*defaultLogger).Errorln Authentication FAILED                        
--- PASS: TestSnowflake_RevokeUser (12.02s)
    --- PASS: TestSnowflake_RevokeUser/username_revoke (4.11s)
    --- PASS: TestSnowflake_RevokeUser/default_revoke (4.39s)
    --- PASS: TestSnowflake_RevokeUser/name_revoke (3.52s)
=== RUN   TestSnowflake_DefaultUsernameTemplate
--- PASS: TestSnowflake_DefaultUsernameTemplate (2.93s)
=== RUN   TestSnowflake_CustomUsernameTemplate
--- PASS: TestSnowflake_CustomUsernameTemplate (2.80s)
PASS
ok      github.com/hashicorp/vault-plugin-database-snowflake    49.136s
```