### PR TITLE
+ add multiplexing support

### DIFF
--- a/cmd/vault-plugin-database-snowflake/main.go
+++ b/cmd/vault-plugin-database-snowflake/main.go
@@ -18,12 +18,7 @@ func main() {
 
 // Run instantiates a SnowflakeSQL object, and runs the RPC server for the plugin
 func Run() error {
-	dbType, err := snowflake.New()
-	if err != nil {
-		return err
-	}
-
-	dbplugin.Serve(dbType.(dbplugin.Database))
+	dbplugin.ServeMultiplex(snowflake.New)
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
-	github.com/hashicorp/vault/sdk v0.5.1-0.20220603231509-4ac2b575faf5
+	github.com/hashicorp/vault/sdk v0.5.3
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/snowflakedb/gosnowflake v1.6.3
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/vault/sdk v0.5.1-0.20220603231509-4ac2b575faf5 h1:79X8/x8owo4i/73JcFJNFeD5Hh1yUE0cQzKRr+2z7nA=
-github.com/hashicorp/vault/sdk v0.5.1-0.20220603231509-4ac2b575faf5/go.mod h1:SAFvvhkLHw7olfm6eQpZbMxGIVpPjNW9LLGCEWeeeCA=
+github.com/hashicorp/vault/sdk v0.5.3 h1:PWY8sq/9pRrK9vUIy75qCH2Jd8oeENAgkaa/qbhzFrs=
+github.com/hashicorp/vault/sdk v0.5.3/go.mod h1:DoGraE9kKGNcVgPmTuX357Fm6WAx1Okvde8Vp3dPDoU=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=


### PR DESCRIPTION
# Overview
Add multiplexing support. Multiple instances of the same plugin will now share the same underlying process.
```
go get github.com/hashicorp/vault/sdk@sdk/v0.5.3
go mod tidy
```

# Related Issues/Pull Requests
Similar to https://github.com/hashicorp/vault-plugin-database-couchbase/pull/30


CI is failing due to associated acceptance account being locked, doesn't seem related to the changes:
`Your account has been locked. To continue using Snowflake, please contact support.`
