### PR TITLE
Allow Parallel Requests to Snowflake

### DIFF
--- a/snowflake.go
+++ b/snowflake.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/errwrap"
@@ -63,6 +64,7 @@ func new() *SnowflakeSQL {
 
 type SnowflakeSQL struct {
 	*connutil.SQLConnectionProducer
+	sync.RWMutex
 
 	usernameProducer template.StringTemplate
 }
@@ -117,8 +119,8 @@ func (s *SnowflakeSQL) Initialize(ctx context.Context, req dbplugin.InitializeRe
 }
 
 func (s *SnowflakeSQL) NewUser(ctx context.Context, req dbplugin.NewUserRequest) (dbplugin.NewUserResponse, error) {
-	s.Lock()
-	defer s.Unlock()
+	s.RLock()
+	defer s.RUnlock()
 
 	statements := req.Statements.Commands
 	if len(statements) == 0 {
@@ -194,8 +196,8 @@ func (s *SnowflakeSQL) generateUsername(req dbplugin.NewUserRequest) (string, er
 }
 
 func (s *SnowflakeSQL) UpdateUser(ctx context.Context, req dbplugin.UpdateUserRequest) (dbplugin.UpdateUserResponse, error) {
-	s.Lock()
-	defer s.Unlock()
+	s.RLock()
+	defer s.RUnlock()
 
 	if req.Username == "" {
 		err := fmt.Errorf("a username must be provided to update a user")
@@ -326,8 +328,8 @@ func (s *SnowflakeSQL) updateUserExpiration(ctx context.Context, tx *sql.Tx, use
 }
 
 func (s *SnowflakeSQL) DeleteUser(ctx context.Context, req dbplugin.DeleteUserRequest) (dbplugin.DeleteUserResponse, error) {
-	s.Lock()
-	defer s.Unlock()
+	s.RLock()
+	defer s.RUnlock()
 
 	username := req.Username
 	statements := req.Statements.Commands


### PR DESCRIPTION
We noticed that multiple requests happening at the same time was very slow, and often resulted in context canceled. We noticed that couchbase had a similar issue [here](https://github.com/hashicorp/vault-plugin-database-couchbase/pull/24/files) and I'm replicating that change here. 

Before change:
![image](https://user-images.githubusercontent.com/23107237/195709781-036f2cd1-b9bd-4bf9-9d2c-50d460681506.png)

After change:
![image](https://user-images.githubusercontent.com/23107237/195709839-5f9135f9-580a-4881-a578-14ad50120a8c.png)
