### PR TITLE
New default statement for user delete

### DIFF
--- a/snowflake.go
+++ b/snowflake.go
@@ -31,7 +31,7 @@ alter user {{name}} set PASSWORD = '{{password}}';
 alter user {{name}} set RSA_PUBLIC_KEY = '{{public_key}}';
 `
 	defaultSnowflakeDeleteSQL = `
-drop user {{name}};
+drop user if exists {{name}};
 `
 	defaultUserNameTemplate = `{{ printf "v_%s_%s_%s_%s" (.DisplayName | truncate 32) (.RoleName | truncate 32) (random 20) (unix_time) | truncate 255 | replace "-" "_" }}`
 )


### PR DESCRIPTION
The default behavior here should only delete the user if it exists to avoid unnecessary errors. Perhaps we could also log out that the user doesn't exist in auditing, but i don't believe we should leave the default statement as it is today.

Error:

`| User '<token>_STGT_W8KAWMCCPDJQRP4BMPGJ_1665647456' does not exist or not authorized.`


Reason for Change:

> The [DROP USER](https://dev.mysql.com/doc/refman/5.6/en/drop-user.html) statement removes one or more MySQL accounts and their privileges. It removes privilege rows for the account from all grant tables. An error occurs for accounts that do not exist.

https://dev.mysql.com/doc/refman/5.6/en/drop-user.html

Results:

No errors for users not existing causing irrevocable leases