### PR TITLE
fix acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ dev: fmtcheck generate
 test: fmtcheck generate
 	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= go test -v -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=20m -parallel=4
 
+test-acc: fmtcheck generate
+	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC=1 go test -v -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=20m -parallel=4
+
 testcompile: fmtcheck generate
 	@for pkg in $(TEST) ; do \
 		go test -v -c -tags='$(BUILD_TAGS)' $$pkg -parallel=4 ; \


### PR DESCRIPTION
This PR fixes the broken acceptance tests after updating the creds in CircleCI. We have made the following changes:

- add makefile target for acceptance tests
- use the `public` role for user grants
- ensure all users created for the tests are cleaned up

<details><summary>Acceptance test output</summary>

```
$ make test-acc
==> Checking that code complies with gofmt requirements...
go generate
CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC=1 go test -v -tags='vault-plugin-database-snowflake' $(go list ./...)  -count=1 -timeout=20m -parallel=4
=== RUN   TestSnowflakeSQL_Initialize
--- PASS: TestSnowflakeSQL_Initialize (1.16s)
=== RUN   TestSnowflake_NewUser
=== RUN   TestSnowflake_NewUser/new_user_with_password_credential_using_username_and_split_statements
=== RUN   TestSnowflake_NewUser/new_user_with_2048_bit_rsa_private_key_credential
=== RUN   TestSnowflake_NewUser/new_user_with_3072_bit_rsa_private_key_credential
=== RUN   TestSnowflake_NewUser/new_user_with_4096_bit_rsa_private_key_credential_and_split_statements
=== RUN   TestSnowflake_NewUser/new_user_with_empty_creation_statements
=== RUN   TestSnowflake_NewUser/new_user_with_password_credential_using_name
--- PASS: TestSnowflake_NewUser (17.67s)
    --- PASS: TestSnowflake_NewUser/new_user_with_password_credential_using_username_and_split_statements (3.57s)
    --- PASS: TestSnowflake_NewUser/new_user_with_2048_bit_rsa_private_key_credential (2.58s)
    --- PASS: TestSnowflake_NewUser/new_user_with_3072_bit_rsa_private_key_credential (2.81s)
    --- PASS: TestSnowflake_NewUser/new_user_with_4096_bit_rsa_private_key_credential_and_split_statements (5.16s)
    --- PASS: TestSnowflake_NewUser/new_user_with_empty_creation_statements (0.72s)
    --- PASS: TestSnowflake_NewUser/new_user_with_password_credential_using_name (2.83s)
=== RUN   TestSnowflake_RenewUser
--- PASS: TestSnowflake_RenewUser (6.21s)
=== RUN   TestSnowflake_RevokeUser
=== RUN   TestSnowflake_RevokeUser/default_revoke
time="2023-01-04T12:03:47-06:00" level=error msg="Authentication FAILED" func="gosnowflake.(*defaultLogger).Errorln" file="log.go:240"
=== RUN   TestSnowflake_RevokeUser/name_revoke
time="2023-01-04T12:03:50-06:00" level=error msg="Authentication FAILED" func="gosnowflake.(*defaultLogger).Errorln" file="log.go:240"
=== RUN   TestSnowflake_RevokeUser/username_revoke
time="2023-01-04T12:03:53-06:00" level=error msg="Authentication FAILED" func="gosnowflake.(*defaultLogger).Errorln" file="log.go:240"
--- PASS: TestSnowflake_RevokeUser (10.12s)
    --- PASS: TestSnowflake_RevokeUser/default_revoke (3.46s)
    --- PASS: TestSnowflake_RevokeUser/name_revoke (3.43s)
    --- PASS: TestSnowflake_RevokeUser/username_revoke (3.22s)
=== RUN   TestSnowflake_DefaultUsernameTemplate
--- PASS: TestSnowflake_DefaultUsernameTemplate (2.32s)
=== RUN   TestSnowflake_CustomUsernameTemplate
--- PASS: TestSnowflake_CustomUsernameTemplate (2.66s)
PASS
ok  	github.com/hashicorp/vault-plugin-database-snowflake	40.959s
?   	github.com/hashicorp/vault-plugin-database-snowflake/cmd/vault-plugin-database-snowflake	[no test files]
```

</details>