### PR TITLE
Remove gox in favor of go build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 TOOL?=vault-plugin-database-snowflake
 TEST?=$$(go list ./...)
 VETARGS?=-asmdecl -atomic -bool -buildtags -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr
-EXTERNAL_TOOLS=\
-	github.com/mitchellh/gox
+EXTERNAL_TOOLS=
 BUILD_TAGS?=${TOOL}
 GOFMT_FILES?=$$(find . -name '*.go')
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Feature requests can be submitted in the Issues section as well.
 ## Quick Links
 
  * [Database Secrets Engine for Snowflake - Docs](https://www.vaultproject.io/docs/secrets/databases/snowflake)
- * [Database Secrets Engine for Snowflake - API Docs](https://www.vaultproject.io/api-docs/secret/databases/snowflake)
+ * [Database Secrets Engine for Snowflake - API Docs](https://developer.hashicorp.com/vault/api-docs/secret/databases/snowflake)
  * [Snowflake Website](https://www.snowflake.com/)
  * [Vault Website](https://www.vaultproject.io)
  

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,6 +8,8 @@ TOOL=vault-plugin-database-snowflake
 # This script builds the application from source for multiple platforms.
 set -e
 
+GO_CMD=${GO_CMD:-go}
+
 # Get the parent directory of where this script is.
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
@@ -23,11 +25,6 @@ BUILD_TAGS="${BUILD_TAGS}:-${TOOL}"
 GIT_COMMIT="$(git rev-parse HEAD)"
 GIT_DIRTY="$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)"
 
-# Determine the arch/os combos we're building for
-XC_ARCH=${XC_ARCH:-"386 amd64"}
-XC_OS=${XC_OS:-linux darwin windows freebsd openbsd netbsd solaris}
-XC_OSARCH=${XC_OSARCH:-"linux/386 linux/amd64 linux/arm linux/arm64 darwin/386 darwin/amd64 darwin/arm64 windows/386 windows/amd64 freebsd/386 freebsd/amd64 freebsd/arm openbsd/386 openbsd/amd64 openbsd/arm netbsd/386 netbsd/amd64 netbsd/arm solaris/amd64"}
-
 GOPATH=${GOPATH:-$(go env GOPATH)}
 case $(uname) in
     CYGWIN*)
@@ -41,46 +38,21 @@ rm -f bin/*
 rm -rf pkg/*
 mkdir -p bin/
 
-# If its dev mode, only build for our self
-if [ "${VAULT_DEV_BUILD}x" != "x" ]; then
-    XC_OS=$(go env GOOS)
-    XC_ARCH=$(go env GOARCH)
-    XC_OSARCH=$(go env GOOS)/$(go env GOARCH)
-fi
-
 # Build!
-echo "==> Building..."
-gox \
-    -osarch="${XC_OSARCH}" \
+${GO_CMD} build \
+    -gcflags "${GCFLAGS}" \
     -ldflags "-X github.com/hashicorp/${TOOL}/version.GitCommit='${GIT_COMMIT}${GIT_DIRTY}'" \
-    -output "pkg/{{.OS}}_{{.Arch}}/${TOOL}" \
-    -tags="${BUILD_TAGS}" \
-    ./cmd/$TOOL
+    -o "bin/${TOOL}" \
+    -tags "${BUILD_TAGS}" \
+    "${DIR}/cmd/${TOOL}"
 
 # Move all the compiled things to the $GOPATH/bin
 OLDIFS=$IFS
 IFS=: MAIN_GOPATH=($GOPATH)
 IFS=$OLDIFS
 
-# Copy our OS/Arch to the bin/ directory
-DEV_PLATFORM="./pkg/$(go env GOOS)_$(go env GOARCH)"
-for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
-    cp ${F} bin/
-    cp ${F} ${MAIN_GOPATH}/bin/
-done
-
-if [ "${VAULT_DEV_BUILD}x" = "x" ]; then
-    # Zip and copy to the dist dir
-    echo "==> Packaging..."
-    for PLATFORM in $(find ./pkg -mindepth 1 -maxdepth 1 -type d); do
-        OSARCH=$(basename ${PLATFORM})
-        echo "--> ${OSARCH}"
-
-        pushd $PLATFORM >/dev/null 2>&1
-        zip ../${OSARCH}.zip ./*
-        popd >/dev/null 2>&1
-    done
-fi
+rm -f ${MAIN_GOPATH}/bin/${TOOL}
+cp bin/${TOOL} ${MAIN_GOPATH}/bin/
 
 # Done!
 echo

--- a/snowflake.go
+++ b/snowflake.go
@@ -34,7 +34,7 @@ alter user {{name}} set PASSWORD = '{{password}}';
 alter user {{name}} set RSA_PUBLIC_KEY = '{{public_key}}';
 `
 	defaultSnowflakeDeleteSQL = `
-drop user if exists {{name}};
+drop user {{name}};
 `
 	defaultUserNameTemplate = `{{ printf "v_%s_%s_%s_%s" (.DisplayName | truncate 32) (.RoleName | truncate 32) (random 20) (unix_time) | truncate 255 | replace "-" "_" }}`
 )

--- a/snowflake.go
+++ b/snowflake.go
@@ -34,7 +34,7 @@ alter user {{name}} set PASSWORD = '{{password}}';
 alter user {{name}} set RSA_PUBLIC_KEY = '{{public_key}}';
 `
 	defaultSnowflakeDeleteSQL = `
-drop user {{name}};
+drop user if exists {{name}};
 `
 	defaultUserNameTemplate = `{{ printf "v_%s_%s_%s_%s" (.DisplayName | truncate 32) (.RoleName | truncate 32) (random 20) (unix_time) | truncate 255 | replace "-" "_" }}`
 )


### PR DESCRIPTION
gox is no longer maintained and releases are done with `go build` now. See https://github.com/hashicorp/vault/pull/16353 where we removed gox in Vault.