### PR TITLE
fix bulk upgrade workflow

### DIFF
--- a/.github/workflows/bulk-dep-upgrades.yaml
+++ b/.github/workflows/bulk-dep-upgrades.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Open pull request if needed
         if: steps.changes.outputs.count > 0
         env:
-          GITHUB_TOKEN: ${{ secrets.VAULT_ECO_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.VAULT_ECO_GITHUB_TOKEN }}
         # Only open a PR if the branch is not attached to an existing one
         run: |
           PR=$(gh pr list --head "$BRANCH_NAME" --json number -q '.[0].number')


### PR DESCRIPTION
The docs say to use `GITHUB_TOKEN` but the [run that failed](https://github.com/hashicorp/vault-plugin-database-snowflake/actions/runs/4504395896/jobs/7928814960) said to use `GH_TOKEN`??? Let's try that

