### PR TITLE
Use same token for checkout and GH CLI

### DIFF
--- a/.github/workflows/bulk-dep-upgrades.yaml
+++ b/.github/workflows/bulk-dep-upgrades.yaml
@@ -9,7 +9,7 @@ jobs:
     # using `main` as the ref will keep your workflow up-to-date
     uses: hashicorp/vault-workflows-common/.github/workflows/bulk-dependency-updates.yaml@main
     secrets:
-      REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO_GITHUB_TOKEN: ${{ secrets.VAULT_ECO_GITHUB_TOKEN }}
       VAULT_ECO_GITHUB_TOKEN: ${{ secrets.VAULT_ECO_GITHUB_TOKEN }}
     with:
       # either hashicorp/vault-ecosystem-applications or hashicorp/vault-ecosystem-foundations


### PR DESCRIPTION
We should be able to just use a single token for the whole job.