### PR TITLE
Add update plugin check workflow

### DIFF
--- a/.github/workflows/hw-bulk-dep-upgrades-with-dispatch.yml
+++ b/.github/workflows/hw-bulk-dep-upgrades-with-dispatch.yml
@@ -1,0 +1,15 @@
+name: Upgrade dependencies
+on:
+  workflow_dispatch:
+
+jobs:
+  upgrade:
+    # using `main` as the ref will keep your workflow up-to-date
+    uses: hashicorp/vault-workflows-common/.github/workflows/bulk-dependency-updates.yaml@add-update-plugin-check-workflow
+    secrets:
+      VAULT_ECO_GITHUB_TOKEN: ${{ secrets.VAULT_ECO_GITHUB_TOKEN }}
+    with:
+      # either hashicorp/vault-ecosystem-applications or hashicorp/vault-ecosystem-foundations
+      reviewer-team: hashicorp/vault-ecosystem-applications
+      repository: ${{ github.repository }}
+      run-id: ${{ github.run_id }}

--- a/.github/workflows/hw-bulk-dep-upgrades-with-dispatch.yml
+++ b/.github/workflows/hw-bulk-dep-upgrades-with-dispatch.yml
@@ -11,5 +11,5 @@ jobs:
     with:
       # either hashicorp/vault-ecosystem-applications or hashicorp/vault-ecosystem-foundations
       reviewer-team: hashicorp/vault-ecosystem-applications
-      repository: ${{ github.repository }}
+      repository: vault-plugin-database-snowflake
       run-id: ${{ github.run_id }}

--- a/.github/workflows/hw-bulk-dep-upgrades-with-dispatch.yml
+++ b/.github/workflows/hw-bulk-dep-upgrades-with-dispatch.yml
@@ -1,4 +1,4 @@
-name: Upgrade dependencies
+name: Upgrade dependencies (dispatch variant)
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
This is a hack-week related PR that adds a separate workflow that is a copy of the existing dependency upgrade one.

Normally I would try to avoid merging this sort of thing to the main branch, but for workflow_dispach actions to be seen, the file needs to be on the default branch.