### PR TITLE
Enable query parameters parsing in connection URL for keypair auth

### DIFF
--- a/connection_producer.go
+++ b/connection_producer.go
@@ -197,11 +197,35 @@ func (c *snowflakeConnectionProducer) Close() error {
 
 // Open the DB connection to Snowflake or return an error.
 func openSnowflake(connectionURL, username string, providedPrivateKey []byte) (*sql.DB, error) {
-	// Parse the connection_url for required fields. Should be of
-	// the form <account_name>.snowflakecomputing.com/<db_name>
-	accountName, dbName, err := parseSnowflakeFieldsFromURL(connectionURL)
+	cfg, err := getSnowflakeConfig(connectionURL, username, providedPrivateKey)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error constructing snowflake config: %w", err)
+	}
+	connector := gosnowflake.NewConnector(gosnowflake.SnowflakeDriver{}, *cfg)
+
+	return sql.OpenDB(connector), nil
+}
+
+func getSnowflakeConfig(connectionURL, username string, providedPrivateKey []byte) (*gosnowflake.Config, error) {
+	// <account_name>.snowflakecomputing.com/<db_name>?queryParameters...
+	u, err := url.Parse(connectionURL)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing Snowflake connection URL %s; err=%w", connectionURL, err)
+	}
+
+	// add authenticator query param to URL to indicate JWT auth
+	// https://pkg.go.dev/github.com/snowflakedb/gosnowflake#hdr-JWT_authentication
+	q := u.Query()
+	q.Set("authenticator", gosnowflake.AuthTypeJwt.String())
+	//q.Set("privateKey", "true") // This is needed to avoid gosnowflake trying to read the private key from a file path
+	u.RawQuery = q.Encode()
+
+	// construct dsn for gosnowflake
+	// "user:""@<account_name>.snowflakecomputing.com/<db_name>?queryParameters...
+	dsn := fmt.Sprintf("%s:%s@%s", username, "", u.String())
+	cfg, err := gosnowflake.ParseDSN(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing Snowflake DSN %s; err=%w", dsn, err)
 	}
 
 	privateKey, err := getPrivateKey(providedPrivateKey)
@@ -209,16 +233,9 @@ func openSnowflake(connectionURL, username string, providedPrivateKey []byte) (*
 		return nil, err
 	}
 
-	snowflakeConfig := &gosnowflake.Config{
-		Account:       accountName,
-		Database:      dbName,
-		User:          username,
-		Authenticator: gosnowflake.AuthTypeJwt,
-		PrivateKey:    privateKey,
-	}
-	connector := gosnowflake.NewConnector(gosnowflake.SnowflakeDriver{}, *snowflakeConfig)
+	cfg.PrivateKey = privateKey
 
-	return sql.OpenDB(connector), nil
+	return cfg, nil
 }
 
 // parseSnowflakeFieldsFromURL uses a regex to extract account and DB

--- a/snowflake_test.go
+++ b/snowflake_test.go
@@ -95,7 +95,53 @@ func TestSnowflakeSQL_Initialize(t *testing.T) {
 		db := new()
 		defer dbtesting.AssertClose(t, db)
 
-		connURL, rawBase64PrivateKey, user, err := getKeyPairAuthParameters()
+		connURL, rawBase64PrivateKey, user, err := getKeyPairAuthParameters("")
+		if err != nil {
+			t.Fatalf("failed to retrieve connection URL: %s", err)
+		}
+
+		// decode base64 encoded private key from environment
+		privateKey, err := base64.StdEncoding.DecodeString(rawBase64PrivateKey)
+		if err != nil {
+			t.Fatalf("failed to decode private key: %s", err)
+		}
+
+		expectedConfig := map[string]interface{}{
+			"connection_url": connURL,
+			"username":       user,
+			"private_key":    privateKey,
+			dbplugin.SupportedCredentialTypesKey: []interface{}{
+				dbplugin.CredentialTypePassword.String(),
+				dbplugin.CredentialTypeRSAPrivateKey.String(),
+			},
+		}
+		req := dbplugin.InitializeRequest{
+			Config: map[string]interface{}{
+				"connection_url": connURL,
+				"username":       user,
+				"private_key":    privateKey,
+			},
+			VerifyConnection: true,
+		}
+		resp := dbtesting.AssertInitialize(t, db, req)
+		if !reflect.DeepEqual(resp.Config, expectedConfig) {
+			t.Fatalf("Actual: %#v\nExpected: %#v", resp.Config, expectedConfig)
+		}
+
+		connProducer := db.snowflakeConnectionProducer
+		if !connProducer.Initialized {
+			t.Fatal("Database should be initialized")
+		}
+	})
+
+	// the environment variable SNOWFLAKE_PRIVATE_KEY in CI
+	// is a base64 encoded string. As such, this test expects the
+	// input for the variable to be base64 encoded
+	t.Run("keypair auth with query params", func(t *testing.T) {
+		db := new()
+		defer dbtesting.AssertClose(t, db)
+
+		connURL, rawBase64PrivateKey, user, err := getKeyPairAuthParameters("disableOCSPChecks=true&client_session_keep_alive=true")
 		if err != nil {
 			t.Fatalf("failed to retrieve connection URL: %s", err)
 		}
@@ -506,7 +552,7 @@ func dsnString() (string, error) {
 	return dsnString, nil
 }
 
-func getKeyPairAuthParameters() (connURL string, pKey string, user string, err error) {
+func getKeyPairAuthParameters(optionalQueryParams string) (connURL string, pKey string, user string, err error) {
 	user = os.Getenv(envVarSnowflakeUser)
 	pKey = os.Getenv(envVarSnowflakePrivateKey)
 	account := os.Getenv(envVarSnowflakeAccount)
@@ -527,6 +573,10 @@ func getKeyPairAuthParameters() (connURL string, pKey string, user string, err e
 	}
 
 	connURL = fmt.Sprintf("%s.snowflakecomputing.com/%s", user, database)
+
+	if optionalQueryParams != "" {
+		connURL = fmt.Sprintf("%s?%s", connURL, optionalQueryParams)
+	}
 
 	return connURL, pKey, user, err
 }


### PR DESCRIPTION
# Overview
When we initially supported keypairs, we were not parsing additional query parameters passed into the Connection URL. This PR fixes that while maintaining backwards compatibility with userpass and the previous keypair auth release.

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x] Backwards compatible
[ ] Changelog entry added. See [Updating the Changelog](https://github.com/hashicorp/vault-plugin-database-snowflake/blob/main/README.md#updating-the-changelog).

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
